### PR TITLE
Update configuration.yaml for ESPHome >=2024.6

### DIFF
--- a/docs/source/files/configuration.yaml
+++ b/docs/source/files/configuration.yaml
@@ -26,7 +26,7 @@ api:
 
 # Enable Over The Air updates
 ota:
-
+  platform: esphome
 
 #Public location of this yaml file
 dashboard_import:


### PR DESCRIPTION
ESPHome >=2024.6 requires additional syntax for the 'ota:' section to build new firmware.